### PR TITLE
Add entry on context ordering

### DIFF
--- a/index.html
+++ b/index.html
@@ -310,9 +310,9 @@
 
       <section>
         <h3 id="context-order">Ordering of array elements</h3>
-        <p class="practicedesc">By default, arrays in <a class="externalDFN" href="https://www.w3.org/TR/json-ld/#sets-and-lists">JSON-LD do not convey any ordering of contained elements</a>.
+        <p class="practicedesc">By default, <a class="externalDFN" href="https://www.w3.org/TR/json-ld/#sets-and-lists">arrays in JSON-LD do not convey any ordering of contained elements</a>.
         However, for the processing of contexts, the ordering of elements in arrays <em>does</em> matter.
-        As such, when writing array-based contexts, this fact SHOULD be kept in mind.</p>
+        As such, when writing array-based contexts, this fact should be kept in mind.</p>
         <p>Ordered contexts in arrays allow inheritance and overriding of context entries.
         When processing the following example, the first <code>name</code> entry will be overridden by the second <code>name</code> entry.</p>
         <pre class="example" title="Overriding name term">

--- a/index.html
+++ b/index.html
@@ -307,6 +307,70 @@
           }
         </pre>
       </section>
+
+      <section>
+        <h3 id="context-order">Ordering of array elements</h3>
+        <p class="practicedesc">By default, arrays in <a class="externalDFN" href="https://www.w3.org/TR/json-ld/#sets-and-lists">JSON-LD do not convey any ordering of contained elements</a>.
+        However, for the processing of contexts, the ordering of elements in arrays <em>does</em> matter.
+        As such, when writing array-based contexts, this fact SHOULD be kept in mind.</p>
+        <p>Ordered contexts in arrays allow inheritance and overriding of context entries.
+        When processing the following example, the first <code>name</code> entry will be overridden by the second <code>name</code> entry.</p>
+        <pre class="example" title="Overriding name term">
+          {
+            "@context": [
+              {
+                "id": "@id",
+                "name": "http://schema.org/name"
+              },
+              {
+                "name": "http://xmlns.com/foaf/0.1/name"
+              }
+            ],
+            "@id": "http://www.wikidata.org/entity/Q76",
+            <strong>"name": "Barack Obama"</strong>
+          }
+        </pre>
+        <p>Order is important when processing <a class="externalDFN" href="https://www.w3.org/TR/json-ld/#protected-term-definitions">protected terms</a>.
+        While the first example will cause a term redefinition error, the second example will not throw this error.</p>
+        <pre class="example" title="Failing term redefinition">
+          {
+            "@context": [
+              {
+                "@version": 1.1,
+                "name": {
+                  "@id": "http://schema.org/name",
+                  "@protected": true
+                }
+              },
+              {
+                "name": "http://xmlns.com/foaf/0.1/name"
+              }
+            ],
+            "@id": "http://www.wikidata.org/entity/Q76",
+            <strong>"name": "Barack Obama"</strong>
+          }
+        </pre>
+        <pre class="example" title="Non-failing term redefinition">
+          {
+            "@context": [
+              {
+                "name": "http://xmlns.com/foaf/0.1/name"
+              },
+              {
+                "@version": 1.1,
+                "Person": "http://schema.org/Person",
+                "knows": "http://schema.org/knows",
+                "name": {
+                  "@id": "http://schema.org/name",
+                  "@protected": true
+                }
+              }
+            ],
+            "@id": "http://www.wikidata.org/entity/Q76",
+            <strong>"name": "Barack Obama"</strong>
+          }
+        </pre>
+      </section>
     </section>
 
 


### PR DESCRIPTION
This section discussed the importance of array order in context processing, with protected term overriding as one example.

Closes #2.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rubensworks/json-ld-bp/pull/27.html" title="Last updated on Feb 15, 2020, 1:41 PM UTC (95efbc7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-bp/27/7bb2bc0...rubensworks:95efbc7.html" title="Last updated on Feb 15, 2020, 1:41 PM UTC (95efbc7)">Diff</a>