### PR TITLE
sync common files

### DIFF
--- a/common/jsonld.js
+++ b/common/jsonld.js
@@ -3,27 +3,86 @@ const jsonld = {
   // Extend or override global respec references
   localBiblio: {
     // aliases to known references
-    "swagger": {
-      "publisher": "Open API Initiative (OAI)",
-      "title": "SWAGGER: The World's Most Popular Framework for APIs",
-      "href" : "http://swagger.io",
-      "date": "2016-01-01"
-    },
-    "json-ld-best-practice-caching": {
-      "authors": [
+    "JSON-LD10": {
+      title: "JSON-LD 1.0",
+      href: "https://www.w3.org/TR/2014/REC-json-ld-20140116/",
+      publisher: "W3C",
+      date: "16 January 2014",
+      status: "W3C Recommendation",
+      authors: [
         "Manu Sporny",
-        "David Longley"
-      ],
-      "title": "JSON-LD Best Practice: Context Caching",
-      "href": "http://manu.sporny.org/2016/json-ld-context-caching/",
-      "date": "2016-04-24"
+        "Gregg Kellogg",
+        "Marcus Langhaler"
+      ]
     },
-    "seo-strings-to-things": {
-      "authors": ["Aaron Bradley"],
-      "title": "Semantic SEO: Making the Shift from Strings to Things",
-      "href": "http://www.seoskeptic.com/semantic-seo-making-shift-strings-things/",
-      "date": "2013-10-02",
-      "publisher": "SEO Skeptic"
-    }
+    "JSON-LD10-API": {
+      title: "JSON-LD 1.0 Processing Algorithms And API",
+      href: "https://www.w3.org/TR/2014/REC-json-ld-api-20140116/",
+      publisher: "W3C",
+      date: "16 January 2014",
+      status: "W3C Recommendation",
+      authors: [
+        "Marcus Langhaler",
+        "Gregg Kellogg",
+        "Manu Sporny"
+      ]
+    },
+    "JSON-LD10-FRAMING": {
+      title: "JSON-LD Framing 1.0",
+      href: "https://json-ld.org/spec/ED/json-ld-framing/20120830/",
+      publisher: "W3C",
+      date: "30 August 2012",
+      status: "Unofficial Draft",
+      authors: [
+        "Manu Sporny",
+        "Gregg Kellogg",
+        "David Longley",
+        "Marcus Langhaler"
+      ]
+    },
+    "IEEE-754-2008": {
+      title: "IEEE 754-2008 Standard for Floating-Point Arithmetic",
+      href: "http://standards.ieee.org/findstds/standard/754-2008.html",
+      publisher: "Institute of Electrical and Electronics Engineers",
+      date: "2008"
+    },
+    "JSON.API": {
+      title: "JSON API",
+      href: "https://jsonapi.org/format/",
+      authors: [
+        'Steve Klabnik',
+        'Yehuda Katz',
+        'Dan Gebhardt',
+        'Tyler Kellen',
+        'Ethan Resnick'
+      ],
+      status: 'unofficial',
+      date: '29 May 2015'
+    },
+    "RFC8785": {
+      title: "JSON Canonicalization Scheme (JCS)",
+      href: 'https://www.rfc-editor.org/rfc/rfc8785',
+      authors: ['A. Rundgren', 'B. Jordan', 'S. Erdtman'],
+      publisher: 'Network Working Group',
+      status: 'Informational',
+      date: 'June 2020'
+    },
+    // These necessary as specref uses the wrong URLs
+    "RFC7231": {
+      title: 'Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content',
+      href: 'https://tools.ietf.org/html/rfc7231',
+      authors: ['R. Fielding, Ed.', 'J. Reschke, Ed'],
+      pubisher: 'IETF',
+      status: 'Proposed Standard',
+      date: 'June 2014'
+    },
+    "RFC8288": {
+      title: 'Web Linking',
+      href: 'https://tools.ietf.org/html/rfc8288',
+      authors: ['M. Nottingham'],
+      pubisher: 'IETF',
+      status: 'Proposed Standard',
+      date: 'October 2017'
+    },
   }
 };


### PR DESCRIPTION
jsonld.js contains localBiblio entries, and had diverged from the reference version (in w3c/json-ld-wg).
3 entries in this repo's version were lost but that is not a problem because:
- 2 of them are actually overridden in index.html
- the 3rd one is not even used in the document