### PR TITLE
Fix common.js to use document.respec.ready (ReSpec v37 CI)

### DIFF
--- a/common/common.js
+++ b/common/common.js
@@ -1,13 +1,12 @@
-/* globals require */
 /* JSON-LD Working Group common spec JavaScript */
 
 /*
 * Implement tabbed examples.
 */
-require(["core/pubsubhub"], (respecEvents) => {
+document.addEventListener("DOMContentLoaded", () => {
   "use strict";
 
-  respecEvents.sub('end-all', (documentElement) => {
+  document.respec.ready.then(() => {
     // remove data-cite on where the citation is to ourselves.
     const selfDfns = Array.from(document.querySelectorAll("dfn[data-cite^='__SPEC__#']"));
     for (const dfn of selfDfns) {


### PR DESCRIPTION
## Summary
- Replace AMD `require(["core/pubsubhub"])` in `common/common.js` with `document.respec.ready.then(postProcess)`, same fix as [w3c/yaml-ld#200](https://github.com/w3c/yaml-ld/pull/200).
- Fixes ReSpec v37 / `w3c/spec-prod@v2` CI failure: `[ERROR] require is not defined` at `common/common.js:7`.

## Test plan
- [ ] CI `Build and Validate` → ReSpec Checker passes on this branch