### PR TITLE
Use archived link for JSON-LD context caching article

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
                 "David Longley"
               ],
               "title": "JSON-LD Best Practice: Context Caching",
-              "href": "http://manu.sporny.org/2016/json-ld-context-caching/",
+              "href": "https://web.archive.org/web/20230131235929/https://manu.sporny.org/2016/json-ld-context-caching/",
               "date": "2016-04-24"
             }
           }


### PR DESCRIPTION
The original Manu Sporny article URL for "JSON-LD Best Practice: Context Caching" is no longer reachable.

This updates the bibliography entry to use the Internet Archive snapshot that preserves the cited article:
https://web.archive.org/web/20230131235929/https://manu.sporny.org/2016/json-ld-context-caching/


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-bp/pull/91.html" title="Last updated on Jul 7, 2026, 8:35 PM UTC (f2b73a7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-bp/91/d492799...f2b73a7.html" title="Last updated on Jul 7, 2026, 8:35 PM UTC (f2b73a7)">Diff</a>