### PR TITLE
Serializing large collections - Pagination

### DIFF
--- a/index.html
+++ b/index.html
@@ -684,11 +684,11 @@
     <p class="practicedesc">
       <span class="practicelab" id="collection-members">Collection members carry dereferencable
         identifiers</span>
-      Members of a collection intended for independent access SHOULD each carry an `@id`,
-      so a consumer can recover any individual member independently of how it arrived, and
-      SHOULD carry an `@type`, so a consumer can interpret a member without refetching it
-      or consulting documentation. Collections whose members are blank nodes — with no
-      identity outside the document — are outside this practice.
+      Members of a collection that are intended to be independently accessible SHOULD
+      each carry an `@id`, so a consumer can recover any individual member without
+      concern for how it arrived, and SHOULD carry an `@type`, so a consumer can
+      interpret a member without refetching it or consulting documentation. Collections
+      whose members are blank nodes — with no identity outside of the document — are beyond this practice.
     </p>
 
     <p>Where the collection URI is a path prefix of member URIs (`.../foo` → `.../foo/bar`),
@@ -709,7 +709,7 @@
     <p class="practicedesc">
       <span class="practicelab" id="hypermedia-controls">Paginate large collections
         using hypermedia controls</span>
-      Represent the collection using [[hydra]] as a `hydra:Collection` carrying `hydra:totalItems` and
+      Represent the collection using [[Hydra]] as a `hydra:Collection` carrying `hydra:totalItems` and
       a `hydra:view` (a `hydra:PartialCollectionView`) with `hydra:first`, `hydra:previous`,
       `hydra:next`, and `hydra:last` links. The view node SHOULD have its own `@id` (the
       current page's URI) so pages are addressable and citable. Clients follow server-minted
@@ -752,8 +752,8 @@
       Emit the pagination relations in an HTTP `Link` header [[RFC8288]] on every paged
       response, in addition to any in-body controls. Link headers are independent of
       serialization, so clients can follow pagination without parsing the body, and
-      representations that cannot carry Hydra controls inline (e.g. `geo+json` or `csv`)
-      advertise the same relations. Where both are present they MUST agree.
+      representations that cannot carry Hydra controls in-line (e.g., `geo+json` or
+      `csv`) advertise the same relations. If both are present, they MUST agree.
     </p>
   </div>
 

--- a/index.html
+++ b/index.html
@@ -23,6 +23,14 @@
               "title": "JSON-LD Best Practice: Context Caching",
               "href": "https://web.archive.org/web/20230131235929/https://manu.sporny.org/2016/json-ld-context-caching/",
               "date": "2016-04-24"
+            },
+            "hydra": {
+              "authors": [
+                "Markus Lanthaler"
+              ],
+              "title": "Hydra Core Vocabulary: A Vocabulary for Hypermedia-Driven Web APIs",
+              "href": "https://www.hydra-cg.com/spec/latest/core/",
+              "publisher": "Hydra W3C Community Group"
             }
           }
         },
@@ -676,8 +684,11 @@
     <p class="practicedesc">
       <span class="practicelab" id="collection-members">Collection members carry dereferencable
         identifiers</span>
-      Each member carries `@id` and `@type` plus their properties, so a consumer can recover
-      any individual member independently of how it arrived.
+      Members of a collection intended for independent access SHOULD each carry an `@id`,
+      so a consumer can recover any individual member independently of how it arrived, and
+      SHOULD carry an `@type`, so a consumer can interpret a member without refetching it
+      or consulting documentation. Collections whose members are blank nodes — with no
+      identity outside the document — are outside this practice.
     </p>
 
     <p>Where the collection URI is a path prefix of member URIs (`.../foo` → `.../foo/bar`),
@@ -698,7 +709,7 @@
     <p class="practicedesc">
       <span class="practicelab" id="hypermedia-controls">Paginate large collections
         using hypermedia controls</span>
-      Represent the collection as a `hydra:Collection` carrying `hydra:totalItems` and
+      Represent the collection using [[hydra]] as a `hydra:Collection` carrying `hydra:totalItems` and
       a `hydra:view` (a `hydra:PartialCollectionView`) with `hydra:first`, `hydra:previous`,
       `hydra:next`, and `hydra:last` links. The view node SHOULD have its own `@id` (the
       current page's URI) so pages are addressable and citable. Clients follow server-minted
@@ -738,9 +749,11 @@
   <div class="practice">
     <p class="practicedesc">
       <span class="practicelab" id="link-headers">Mirror pagination in HTTP Link headers</span>
-      Emit these same links on every paged response so that alternate serializations which
-      cannot carry Hydra controls inline (e.g. `geo+json` or `csv`) advertise the same
-      pagination relations in an HTTP `Link` header [[RFC8288]].
+      Emit the pagination relations in an HTTP `Link` header [[RFC8288]] on every paged
+      response, in addition to any in-body controls. Link headers are independent of
+      serialization, so clients can follow pagination without parsing the body, and
+      representations that cannot carry Hydra controls inline (e.g. `geo+json` or `csv`)
+      advertise the same relations. Where both are present they MUST agree.
     </p>
   </div>
 

--- a/index.html
+++ b/index.html
@@ -666,6 +666,73 @@
   <h2>Serializing Large Collections</h2>
   <p class="ednote">Describe schema.org extension using Role sub-class,
     Hydra collections, and LDP collections.</p>
+  <h3>Pagination</h3>
+    <p>Where streaming JSON-LD is not practical, pagination bounds memory demands 
+    instead. The two are complementary: streaming suits bulk transfer of a whole dataset, 
+    pagination suits interactive and partial access. Publishers unable to implement a 
+    streaming profile SHOULD paginate.</p>
+
+    <div class="practice">
+      <p class="practicedesc">
+      <span class="practicelab" id="hypermedia-controls">Paginate large collections 
+        using hypermedia controls</span>
+      Represent the collection as a `hydra:Collection` carrying `hydra:totalItems` and 
+      a `hydra:view` (a `hydra:PartialCollectionView`) with `first`, `next`, `previous`, 
+      `last` links. The view node should similarly have its own `@id` (the current 
+      page's URI) so pages are addressable and citable. Clients follow server-minted 
+      links rather than constructing URIs.</p>
+    </div>
+
+    <pre class="example"
+       data-transform="updateExample"
+       title="Hydra hypermedia controls for large collections">
+      {
+        "@context": [
+          "http://www.w3.org/ns/hydra/context.jsonld",
+          {
+            "sosa": "http://www.w3.org/ns/sosa/",
+            "geo": "http://www.opengis.net/ont/geosparql#"
+          }
+        ],
+        "@id": "http://example.org/foo",
+        "@type": "hydra:Collection",
+        "totalItems": 66208,
+        "view": {
+          "@id": "http://example.org/foo?page=2",
+          "@type": "hydra:PartialCollectionView",
+          "first": "http://example.org/foo?page=1",
+          "previous": "http://example.org/foo?page=1",
+          "next": "http://example.org/foo?page=3",
+          "last": "http://example.org/foo?page=663"
+        },
+        "member": [
+          {
+            "@id": "http://example.org/foo/bar",
+            "@type": ["sosa:FeatureOfInterest", "geo:Feature"]
+          }
+        ]
+      }
+  </pre>
+
+    <div class="practice">
+      <p class="practicedesc">
+      <span class="practicelab" id="hydra-members">Members dereferenceable identifiers</span>
+      Each member carries `@id` and `@type` plus its' properties; the full representation
+      lives at the member's own URI. Where the collection URI is a path prefix of member URIs
+      (`.../foo` → `.../foo/bar`), the containment is legible to
+      developers who expect JSON API access patterns — but the authoritative relationship is
+      the `hydra:member` assertion, not the path.</p>
+    </div>
+
+    <div class="practice">
+      <p class="practicedesc">
+      <span class="practicelab" id="link-headers">Mirror pagination in HTTP Link headers
+        (RFC 8288)</span>
+      Emit these same links on every paged response to support alternate serializations
+      which MUST NOT carry Hydra controls inline (e.g. `geo+json` or `csv`), so that the
+      view is treated as a resource with different serializations.</p>
+    </div>
+
 </section>
 
 <section class="informative">

--- a/index.html
+++ b/index.html
@@ -664,74 +664,99 @@
 
 <section class="informative">
   <h2>Serializing Large Collections</h2>
-  <p class="ednote">Describe schema.org extension using Role sub-class,
-    Hydra collections, and LDP collections.</p>
+  <p class="ednote">Describe schema.org extension using Role sub-class, and LDP collections.</p>
+
+  <p>Large collections force a choice the serialization itself can't make: deliver everything
+    or deliver a bounded slice with directions to the rest. These two options, streaming and
+    pagination, are a spectrum and not alternatives dependent on the consumer's access pattern
+    and not the collection's size.</p>
+
+  <div class="practice">
+    <p class="practicedesc">
+      <span class="practicelab" id="collection-members">Collection members carry dereferencable
+        identifiers</span>
+      Each member carries `@id` and `@type` plus their properties. Where the collection URI is a
+      path prefix of member URIs (`.../foo` → `.../foo/bar`), the containment is legible to
+      developers who expect JSON API access patterns — but the authoritative relationship is
+      the assertion of membership in the collection, not the path.
+    </p>
+  </div>
+
+  <h3>Streaming</h3>
+  <p class="ednote">Emit the document so a processor can produce RDF incrementally, using
+    approaches outlined in [[json-ld11-streaming]].
+  </p>
+
   <h3>Pagination</h3>
-    <p>Where streaming JSON-LD is not practical, pagination bounds memory demands 
-    instead. The two are complementary: streaming suits bulk transfer of a whole dataset, 
-    pagination suits interactive and partial access. Publishers unable to implement a 
+  <p>Where streaming JSON-LD is not practical, pagination bounds memory demands
+    instead. The two are complementary: streaming suits bulk transfer of a whole dataset,
+    pagination suits interactive and partial access. Publishers unable to implement a
     streaming profile SHOULD paginate.</p>
 
-    <div class="practice">
-      <p class="practicedesc">
-      <span class="practicelab" id="hypermedia-controls">Paginate large collections 
+  <div class="practice">
+    <p class="practicedesc">
+      <span class="practicelab" id="hypermedia-controls">Paginate large collections
         using hypermedia controls</span>
-      Represent the collection as a `hydra:Collection` carrying `hydra:totalItems` and 
-      a `hydra:view` (a `hydra:PartialCollectionView`) with `first`, `next`, `previous`, 
-      `last` links. The view node should similarly have its own `@id` (the current 
-      page's URI) so pages are addressable and citable. Clients follow server-minted 
-      links rather than constructing URIs.</p>
-    </div>
+      Represent the collection as a `hydra:Collection` carrying `hydra:totalItems` and
+      a `hydra:view` (a `hydra:PartialCollectionView`) with `hydra:first`, `hydra:previous`,
+      `hydra:next`, and `hydra:last` links. The view node SHOULD have its own `@id` (the
+      current page's URI) so pages are addressable and citable. Clients follow server-minted
+      links rather than constructing URIs. Membership in the collection is asserted using
+      `hydra:member`.
+    </p>
+  </div>
 
-    <pre class="example"
-       data-transform="updateExample"
-       title="Hydra hypermedia controls for large collections">
+  <pre class="example" data-transform="updateExample" title="Hydra hypermedia controls for large collections">
       {
-        "@context": [
-          "http://www.w3.org/ns/hydra/context.jsonld",
-          {
+        "@context": {
+            "hydra": "http://www.w3.org/ns/hydra/core#",
             "sosa": "http://www.w3.org/ns/sosa/",
             "geo": "http://www.opengis.net/ont/geosparql#"
-          }
-        ],
+        },
         "@id": "http://example.org/foo",
         "@type": "hydra:Collection",
-        "totalItems": 66208,
-        "view": {
+        "hydra:totalItems": 66208,
+        "hydra:view": {
           "@id": "http://example.org/foo?page=2",
           "@type": "hydra:PartialCollectionView",
-          "first": "http://example.org/foo?page=1",
-          "previous": "http://example.org/foo?page=1",
-          "next": "http://example.org/foo?page=3",
-          "last": "http://example.org/foo?page=663"
+          "hydra:first": {"@id": "http://example.org/foo?page=1"},
+          "hydra:previous": {"@id": "http://example.org/foo?page=1"},
+          "hydra:next": {"@id": "http://example.org/foo?page=3"},
+          "hydra:last": {"@id": "http://example.org/foo?page=663"}
         },
-        "member": [
+        "hydra:member": [
           {
             "@id": "http://example.org/foo/bar",
-            "@type": ["sosa:FeatureOfInterest", "geo:Feature"]
+            "@type": ["sosa:FeatureOfInterest", "geo:Feature"],
+            "sosa:hasSample": {"@id": "http://example.org/foo/bar/baz"}
           }
         ]
       }
   </pre>
 
-    <div class="practice">
-      <p class="practicedesc">
-      <span class="practicelab" id="hydra-members">Members dereferenceable identifiers</span>
-      Each member carries `@id` and `@type` plus its' properties; the full representation
-      lives at the member's own URI. Where the collection URI is a path prefix of member URIs
-      (`.../foo` → `.../foo/bar`), the containment is legible to
-      developers who expect JSON API access patterns — but the authoritative relationship is
-      the `hydra:member` assertion, not the path.</p>
-    </div>
-
-    <div class="practice">
-      <p class="practicedesc">
-      <span class="practicelab" id="link-headers">Mirror pagination in HTTP Link headers
-        (RFC 8288)</span>
+  <div class="practice">
+    <p class="practicedesc">
+      <span class="practicelab" id="link-headers">Mirror pagination in HTTP Link headers</span>
       Emit these same links on every paged response to support alternate serializations
-      which MUST NOT carry Hydra controls inline (e.g. `geo+json` or `csv`), so that the
-      view is treated as a resource with different serializations.</p>
-    </div>
+      which cannot carry Hydra controls inline (e.g. `geo+json` or `csv`), so that the
+      view is treated as a resource with different serializations advertise the same pagination
+      relations in an HTTP `Link` header [[RFC8288]].
+    </p>
+  </div>
+
+  <pre class="example" data-content-type="text/plain" data-ignore="true"
+    title="Pagination relations mirrored in an HTTP Link header">
+      GET /foo?page=2 HTTP/1.1
+      Host: example.org
+      Accept: application/geo+json
+
+      HTTP/1.1 200 OK
+      Content-Type: application/geo+json
+      Link: &lt;http://example.org/foo?page=1&gt;; rel="first",
+            &lt;http://example.org/foo?page=1&gt;; rel="prev",
+            &lt;http://example.org/foo?page=3&gt;; rel="next",
+            &lt;http://example.org/foo?page=663&gt;; rel="last"
+    </pre>
 
 </section>
 

--- a/index.html
+++ b/index.html
@@ -668,18 +668,21 @@
 
   <p>Large collections force a choice the serialization itself can't make: deliver everything
     or deliver a bounded slice with directions to the rest. These two options, streaming and
-    pagination, are a spectrum and not alternatives dependent on the consumer's access pattern
-    and not the collection's size.</p>
+    pagination, are a spectrum and not alternatives, dependent on the consumer's access pattern
+    and not the collection's size. Streaming suits bulk transfer of a whole dataset;
+    pagination suits interactive and partial access.</p>
 
   <div class="practice">
     <p class="practicedesc">
       <span class="practicelab" id="collection-members">Collection members carry dereferencable
         identifiers</span>
-      Each member carries `@id` and `@type` plus their properties. Where the collection URI is a
-      path prefix of member URIs (`.../foo` → `.../foo/bar`), the containment is legible to
-      developers who expect JSON API access patterns — but the authoritative relationship is
-      the assertion of membership in the collection, not the path.
+      Each member carries `@id` and `@type` plus their properties, so a consumer can recover
+      any individual member independently of how it arrived.
     </p>
+
+    <p>Where the collection URI is a path prefix of member URIs (`.../foo` → `.../foo/bar`),
+      the containment is legible to developers who expect JSON API access patterns — but the
+      authoritative relationship is the assertion of membership in the collection, not the path.</p>
   </div>
 
   <h3>Streaming</h3>
@@ -688,10 +691,8 @@
   </p>
 
   <h3>Pagination</h3>
-  <p>Where streaming JSON-LD is not practical, pagination bounds memory demands
-    instead. The two are complementary: streaming suits bulk transfer of a whole dataset,
-    pagination suits interactive and partial access. Publishers unable to implement a
-    streaming profile SHOULD paginate.</p>
+  <p>Where streaming JSON-LD is not practical, pagination bounds memory demands instead.
+    Publishers unable to implement a streaming profile SHOULD paginate.</p>
 
   <div class="practice">
     <p class="practicedesc">
@@ -737,10 +738,9 @@
   <div class="practice">
     <p class="practicedesc">
       <span class="practicelab" id="link-headers">Mirror pagination in HTTP Link headers</span>
-      Emit these same links on every paged response to support alternate serializations
-      which cannot carry Hydra controls inline (e.g. `geo+json` or `csv`), so that the
-      view is treated as a resource with different serializations advertise the same pagination
-      relations in an HTTP `Link` header [[RFC8288]].
+      Emit these same links on every paged response so that alternate serializations which
+      cannot carry Hydra controls inline (e.g. `geo+json` or `csv`) advertise the same
+      pagination relations in an HTTP `Link` header [[RFC8288]].
     </p>
   </div>
 

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
               "href": "https://web.archive.org/web/20230131235929/https://manu.sporny.org/2016/json-ld-context-caching/",
               "date": "2016-04-24"
             },
-            "hydra": {
+            "Hydra": {
               "authors": [
                 "Markus Lanthaler"
               ],


### PR DESCRIPTION
Covers the Hydra collection portion of the "Serializing Large Collections" ednote. schema.org Role sub-classing and LDP collections remain open, so the ednote stays. Streaming is a stub pending separate work.

Addresses #93.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/canwaf/json-ld-bp/pull/94.html" title="Last updated on Aug 11, 2026, 8:21 PM UTC (6108103)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/json-ld-bp/94/a7fd4e4...canwaf:6108103.html" title="Last updated on Aug 11, 2026, 8:21 PM UTC (6108103)">Diff</a>